### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "mcpName": "io.github.Antonytm/mcp-sitecore-server",
   "version": "1.3.12",
   "description": "A Model Context Protocol server for Sitecore",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Antonytm/mcp-sitecore-server.git"


### PR DESCRIPTION
## Summary

- add Apache-2.0 license metadata to the package manifest
- align npm metadata with the repository license

## Verification

- `npm view @antonytm/mcp-sitecore-server@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'Apache-2.0') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
