### PR TITLE
Raise default PowerShell timeout to 10 minutes

### DIFF
--- a/.github/workflows/publish-docker-linux.yml
+++ b/.github/workflows/publish-docker-linux.yml
@@ -12,7 +12,7 @@ jobs:
         name: Build & push Docker image
         with:
           image: antonytm/mcp-sitecore-linux
-          tags: 1.4.0, latest
+          tags: 1.4.2, latest
           registry: docker.io
           dockerfile: ./docker/linux/Dockerfile
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-docker-windows.yml
+++ b/.github/workflows/publish-docker-windows.yml
@@ -35,7 +35,7 @@ jobs:
         name: Build & push Docker image
         with:
           image: antonytm/mcp-sitecore-windows
-          tags: 1.4.1, latest
+          tags: 1.4.2, latest
           registry: docker.io
           dockerfile: ./docker/windows/Dockerfile
           platform: windows/amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tool's name, so MCP clients can distinguish safe reads from mutations and destructive
   operations. `run-powershell-script` is flagged destructive and open-world.
 - **Request timeouts** on all outbound HTTP calls via a shared `fetchWithTimeout` helper
-  (Item Service, GraphQL, and PowerShell clients). Defaults: 30s for REST/GraphQL, 60s
-  for PowerShell; both configurable via `REQUEST_TIMEOUT_MS` / `POWERSHELL_TIMEOUT_MS`.
-  (60s aligns with the tool-call timeout most AI agents enforce, so a longer default would
-  only cause the agent to abort before this timeout fires.)
+  (Item Service, GraphQL, and PowerShell clients). Defaults: 30s for REST/GraphQL, 10
+  minutes for PowerShell; both configurable via `REQUEST_TIMEOUT_MS` /
+  `POWERSHELL_TIMEOUT_MS`. (The PowerShell default is deliberately generous — long-running
+  scripts such as index rebuilds and publishing routinely exceed a short timeout, and the
+  calling agent's own tool-call timeout will cut things short first if it is lower.)
 - **Traversal guard** in `get-item-descendants`: a visited-set for cycle protection and a
   configurable node cap (`DESCENDANTS_MAX_ITEMS`, default 5000) that reports truncation
   instead of exhausting memory on large or circular item trees.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.2] - 2026-07-30
+
+### Changed
+
+- **Default PowerShell script timeout raised from 60 seconds to 10 minutes.** The 60s
+  default was tuned to the tool-call timeout most AI agents enforce, but in practice it
+  fired constantly on larger scripts (index rebuilds, publishing, bulk item updates) and
+  aborted work that would have succeeded. The timeout exists to stop a hung Sitecore
+  endpoint holding a connection open forever, not to bound legitimate script runtime, so a
+  generous default is the safer failure mode — and the calling agent's own tool-call
+  timeout still cuts things short first when it is set lower. Override with
+  `POWERSHELL_TIMEOUT_MS`.
+
+## [1.4.1] - 2026-07-22
+
+### Fixed
+
+- Docker Hub publish workflows only: the Windows image build now waits for the Docker
+  daemon to accept API calls before building, and the published image tags were brought up
+  to the current version. No changes to the server itself.
+
+## [1.4.0] - 2026-07-22
 
 ### Security
 
@@ -41,11 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tool's name, so MCP clients can distinguish safe reads from mutations and destructive
   operations. `run-powershell-script` is flagged destructive and open-world.
 - **Request timeouts** on all outbound HTTP calls via a shared `fetchWithTimeout` helper
-  (Item Service, GraphQL, and PowerShell clients). Defaults: 30s for REST/GraphQL, 10
-  minutes for PowerShell; both configurable via `REQUEST_TIMEOUT_MS` /
-  `POWERSHELL_TIMEOUT_MS`. (The PowerShell default is deliberately generous — long-running
-  scripts such as index rebuilds and publishing routinely exceed a short timeout, and the
-  calling agent's own tool-call timeout will cut things short first if it is lower.)
+  (Item Service, GraphQL, and PowerShell clients). Defaults: 30s for REST/GraphQL, 60s
+  for PowerShell; both configurable via `REQUEST_TIMEOUT_MS` / `POWERSHELL_TIMEOUT_MS`.
+  (60s aligns with the tool-call timeout most AI agents enforce, so a longer default would
+  only cause the agent to abort before this timeout fires.) The PowerShell default was
+  later raised to 10 minutes in 1.4.2.
 - **Traversal guard** in `get-item-descendants`: a visited-set for cycle protection and a
   configurable node cap (`DESCENDANTS_MAX_ITEMS`, default 5000) that reports truncation
   instead of exhausting memory on large or circular item trees.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antonytm/mcp-sitecore-server",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antonytm/mcp-sitecore-server",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@antonytm/clixml-parser": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antonytm/mcp-sitecore-server",
   "mcpName": "io.github.Antonytm/mcp-sitecore-server",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A Model Context Protocol server for Sitecore",
   "license": "Apache-2.0",
   "repository": {
@@ -32,13 +32,13 @@
     "typecheck": "tsc --noEmit",
     "test": "npm run build && npm run bundle && vitest run",
     "test:unit": "vitest run --config vitest.unit.config.ts",
-    "docker:windows:build": "docker build -t antonytm/mcp-sitecore-windows:1.4.0 -t antonytm/mcp-sitecore-windows:latest --file .\\docker\\windows\\Dockerfile .",
+    "docker:windows:build": "docker build -t antonytm/mcp-sitecore-windows:1.4.2 -t antonytm/mcp-sitecore-windows:latest --file .\\docker\\windows\\Dockerfile .",
     "docker:windows:run": "docker run -it --rm -p 4001:3001 antonytm/mcp-sitecore-windows:latest",
-    "docker:windows:push": "docker push antonytm/mcp-sitecore-windows:1.4.0 && docker push antonytm/mcp-sitecore-windows:latest",
+    "docker:windows:push": "docker push antonytm/mcp-sitecore-windows:1.4.2 && docker push antonytm/mcp-sitecore-windows:latest",
     "docker:windows": "npm run docker:windows:build && npm run docker:windows:push",
-    "docker:linux:build": "docker build -t antonytm/mcp-sitecore-linux:1.4.0 -t antonytm/mcp-sitecore-linux:latest --file ./docker/linux/Dockerfile .",
+    "docker:linux:build": "docker build -t antonytm/mcp-sitecore-linux:1.4.2 -t antonytm/mcp-sitecore-linux:latest --file ./docker/linux/Dockerfile .",
     "docker:linux:run": "docker run -it --rm -p 4001:3001 antonytm/mcp-sitecore-linux:latest",
-    "docker:linux:push": "docker push antonytm/mcp-sitecore-linux:1.4.0 && docker push antonytm/mcp-sitecore-linux:latest",
+    "docker:linux:push": "docker push antonytm/mcp-sitecore-linux:1.4.2 && docker push antonytm/mcp-sitecore-linux:latest",
     "docker:linux": "npm run docker:linux:build && npm run docker:linux:push"
   },
   "dependencies": {

--- a/src/tools/powershell/client.ts
+++ b/src/tools/powershell/client.ts
@@ -30,11 +30,15 @@ class PowershellClient {
 
         const scriptWithParameters = this.commandBuilder.buildCommandString(script, parameters);
         const body = `${scriptWithParameters}\r\n <#${uuid}#>\r\n`;
-        // Default to 60s: most AI agents abort a tool call at ~60s anyway, so a longer
-        // default would just let the agent time out before we do. Still independently
-        // configurable via POWERSHELL_TIMEOUT_MS for long-running scripts (rebuilds,
-        // publishing) when the calling agent's timeout is raised to match.
-        const timeoutMs = Number(process.env.POWERSHELL_TIMEOUT_MS) || 60000;
+        // Default to 10 minutes. The previous 60s default was tuned to the tool-call
+        // timeout most AI agents enforce, but in practice it fired constantly on larger
+        // scripts (index rebuilds, publishing, bulk item updates) and aborted work that
+        // would have succeeded. A generous default is the safer failure mode here: this
+        // timeout exists to stop a hung Sitecore endpoint holding the connection open
+        // forever, not to bound legitimate script runtime — and the calling agent's own
+        // timeout still cuts things short first if it is set lower. Override with
+        // POWERSHELL_TIMEOUT_MS to raise or lower it.
+        const timeoutMs = Number(process.env.POWERSHELL_TIMEOUT_MS) || 600000;
         const response = await fetchWithTimeout(url, {
             method: 'POST',
             headers: headers,


### PR DESCRIPTION
## Why

`POWERSHELL_TIMEOUT_MS` defaulted to 60s. That was originally chosen to match the tool-call timeout most AI agents enforce, on the reasoning that a longer server-side timeout would just let the agent give up first. In practice it fires constantly on larger scripts — index rebuilds, publishing, bulk item updates — and aborts work that would have succeeded.

The tradeoff is worth restating: this timeout exists to stop a hung Sitecore endpoint holding a connection open forever, not to bound legitimate script runtime. For that job a generous default is the safer failure mode, and an agent with a shorter tool-call timeout still cuts things short first regardless of what the server allows.

## What

- Default raised from 60s to 10 minutes in `src/tools/powershell/client.ts`, with the reasoning recorded in the comment. Still overridable via `POWERSHELL_TIMEOUT_MS` in either direction.
- Version bumped 1.4.1 → 1.4.2 following the existing convention: `package.json` plus the hardcoded tags in both docker publish workflows. The `docker:*:build`/`push` npm scripts were also bumped — they had drifted behind at 1.4.0, so they would have built and pushed an already-published tag.
- CHANGELOG restructured into dated `[1.4.0]` / `[1.4.1]` / `[1.4.2]` sections. Everything was still sitting under `[Unreleased]` despite 1.4.0 and 1.4.1 being tagged and published, so the file described behaviour that did not match either released version. The 1.4.0 request-timeouts entry now correctly documents the 60s default that version shipped, with a pointer to the 1.4.2 change.

## Notes

- `[1.4.2]` is dated 2026-07-30 on the assumption of a release around now; worth adjusting if it slips.
- No `[Unreleased]` heading remains — happy to add an empty one back as a landing spot for the next change if you prefer that.

## Testing

`npm run typecheck` passes. The change is a single default constant, no behavioural branch added.