### PR TITLE
fix: run every SPE script as the shell site with master pinned (2.0.1)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,6 +10,10 @@ POWERSHELL_DOMAIN=sitecore
 POWERSHELL_USERNAME=admin
 POWERSHELL_PASSWORD=b
 POWERSHELL_SERVER_URL=https://xmcloudcm.localhost/
+# Site (and content database) every script runs under; `shell` matches the Content Editor and
+# is where a template's default workflow is applied on create. Empty = no switch.
+POWERSHELL_SITE_CONTEXT=shell
+POWERSHELL_CONTEXT_DATABASE=master
 AUTHORIZATION_HEADER=
 # The Authoring and Management GraphQL API. Separate from GRAPHQL_* above: that one talks
 # to the Edge/preview endpoints with an sc_apikey, this one talks to the CM's authoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ Our versioning strategy is as follows:
 - Minor: non-breaking feature additions – no breaking changes (e.g. new tools, improvements)
 - Major: new features + breaking changes (e.g. SDK upgrades, tool renames, protocol revisions)
 
+## 2.0.1
+
+### 🛠 Changed
+
+- **Scripts now run as the `shell` site with `Context.Database` pinned to `master`**, the same
+  context the Content Editor and the SPE ISE use. Sitecore applies a template's `__Default workflow`
+  to a created item only when `Context.Site.EnableWorkflow` is true; the remoting endpoint otherwise
+  resolves its site from the request host, which on a multi-site CM is a content site with workflow
+  off — so items created through `run-powershell-script` (and every SPE-backed tool) landed outside
+  their workflow, silently, while the same create in the Content Editor landed in Draft. Every script
+  is wrapped in a `SiteContextSwitcher` + `DatabaseSwitcher`; a `try` block opens no scope in
+  PowerShell, so output, variables and `return` are unchanged. Visible differences: `[Sitecore.Context]::Site.Name`
+  reads `shell` inside a script, and created items now carry their template's default workflow. New
+  settings `POWERSHELL_SITE_CONTEXT` (default `shell`; empty restores the previous behaviour) and
+  `POWERSHELL_CONTEXT_DATABASE` (default `master`). `sc_site=shell` on the query string was measured and
+  rejected: the shell site redirects to its login page before SPE's basic-auth handler runs.
+
 ## 2.0.0
 
 _Released 2026-09 — a fourth API surface, a tool surface a third smaller per operation, on the v2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,19 @@ client's URL to `http://<host>:3001/mcp` and its transport type to "Streamable H
 | `POWERSHELL_DOMAIN`       | `sitecore` | The domain for PowerShell Remoting API authentication.            |
 | `POWERSHELL_USERNAME`     | —          | The username for PowerShell Remoting API authentication.          |
 | `POWERSHELL_PASSWORD`     | —          | The password for PowerShell Remoting API authentication.          |
+| `POWERSHELL_SITE_CONTEXT` | `shell`    | The Sitecore site every script runs under (a `SiteContextSwitcher` around the script body). `shell` is what the Content Editor and the SPE ISE use, and it is the context in which a template's default workflow is applied to a created item. Set it to an empty value to run scripts under whichever site the request host resolves to, which on a multi-site CM is a content site with workflow off — see the note below. |
+| `POWERSHELL_CONTEXT_DATABASE` | `master` | `Context.Database` inside that switch. `shell` alone would make it `core`, the shell site's own database. Empty leaves the site's database in place. |
+
+**Why scripts run as `shell`.** Sitecore applies a template's `__Default workflow` to a created item only
+when `Context.Site.EnableWorkflow` is true. The Content Editor, Pages and the SPE ISE run as `shell`, where
+it is. The remoting endpoint resolves its site from the request host like any other request, which on a CM
+serving several sites is whichever content site claims that hostname, with workflow off — so a script that
+created pages there left every one of them outside its workflow, and nothing reported it. Every script is
+therefore wrapped in a `SiteContextSwitcher` (plus a `DatabaseSwitcher`, because `shell` on its own makes
+`Context.Database` the `core` database). A `try` block opens no scope in PowerShell, so the script's
+variables, output and `return` are unaffected; the one visible difference is that `[Sitecore.Context]::Site.Name`
+reads `shell`. Passing `sc_site=shell` on the query string instead does not work: the shell site redirects an
+unauthenticated request to its login page before SPE's basic-auth handler runs.
 
 ## Authoring and Management API
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -100,7 +100,7 @@ existing section without its ID is rejected for creating a duplicate.
     - [x] `item-service-get-item-descendants`: returns the descendants of an item by ID
 - [x] Sitecore PowerShell
   - [x] `get-powershell-documentation`: the SPE command reference, revealed progressively. No arguments returns an index of all 129 commands with one-line summaries (~11KB); `command` returns the full page for up to 5 named commands; `search` finds a command by what it does; `category` lists one group. It no longer returns the whole corpus in one result, and the pages for commands that only work inside the SPE console's own UI (`Show-*`, `Invoke-JavaScript`, `Read-Variable`, …) are not bundled at all — nothing reachable over the `remoting` service can call them.
-  - [x] `run-powershell-script`: runs a PowerShell script and returns the output; its description points at the [`guide://bulk-update`](./guides.md) resource for the safe mass-write pattern
+  - [x] `run-powershell-script`: runs a PowerShell script and returns the output; its description points at the [`guide://bulk-update`](./guides.md) resource for the safe mass-write pattern. Like every SPE-backed tool it runs as the `shell` site with `master` as the context database (`POWERSHELL_SITE_CONTEXT` / `POWERSHELL_CONTEXT_DATABASE` in [configuration](./configuration.md)), so an item a script creates receives its template's default workflow exactly as it would from the Content Editor
   - [x] Security
     - [x] `security-get-current-user`: returns the current user
     - [x] `security-get-user`: returns users by exact `identity` or wildcard `filter` (supply one)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antonytm/mcp-sitecore-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antonytm/mcp-sitecore-server",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@antonytm/clixml-parser": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antonytm/mcp-sitecore-server",
   "mcpName": "io.github.Antonytm/mcp-sitecore-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Sitecore Community MCP: read/write access to Sitecore XM Cloud and XM/XP over the Authoring and Management API, the Item Service, GraphQL Edge and Sitecore PowerShell Extensions",
   "license": "Apache-2.0",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/Antonytm/mcp-sitecore-server",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@antonytm/mcp-sitecore-server",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,11 +37,23 @@ const ConfigSchema = z.object({
         username: z.string(),
         password: z.string(),
         serverUrl: z.string().url(),
+        /**
+         * The site every script runs under, via a `SiteContextSwitcher` around the script body.
+         * Sitecore applies a template's default workflow at create time only where
+         * `Context.Site.EnableWorkflow` is true; the remoting endpoint otherwise resolves its
+         * site from the request host, which on a multi-site CM is a content site with workflow
+         * off. `shell` is what the Content Editor and the SPE ISE run as. Empty = no switch.
+         */
+        siteContext: z.string(),
+        /** `Context.Database` inside that switch; `shell` alone would make it `core`. Empty = leave it. */
+        contextDatabase: z.string(),
     }).default({
         domain: "sitecore",
         username: "admin",
         password: "b",
         serverUrl: "https://xmcloudcm.localhost/",
+        siteContext: "shell",
+        contextDatabase: "master",
     }),
     /**
      * The Authoring and Management GraphQL API: one endpoint on the CM that serves the
@@ -86,6 +98,8 @@ export const envSchema = z.object({
     POWERSHELL_USERNAME: z.string().optional(),
     POWERSHELL_PASSWORD: z.string().optional(),
     POWERSHELL_SERVER_URL: z.string().url().optional(),
+    POWERSHELL_SITE_CONTEXT: z.string().optional(),
+    POWERSHELL_CONTEXT_DATABASE: z.string().optional(),
     AUTHORING_ENDPOINT: z.string().url().optional(),
     AUTHORING_TOKEN: z.string().optional(),
     AUTHORING_CLIENT_ID: z.string().optional(),
@@ -203,6 +217,9 @@ const config: Config = {
         username: ENV.POWERSHELL_USERNAME || "admin",
         password: ENV.POWERSHELL_PASSWORD || "b",
         serverUrl: ENV.POWERSHELL_SERVER_URL || "https://xmcloudcm.localhost/",
+        // `??`, not `||`: an explicitly empty value is the documented way to turn the switch off.
+        siteContext: ENV.POWERSHELL_SITE_CONTEXT ?? "shell",
+        contextDatabase: ENV.POWERSHELL_CONTEXT_DATABASE ?? "master",
     },
     authoring: {
         endpoint: resolveAuthoringEndpoint(ENV.AUTHORING_ENDPOINT, itemServiceServerUrl),

--- a/src/tools/powershell/client.ts
+++ b/src/tools/powershell/client.ts
@@ -1,6 +1,6 @@
 import { generateUUID, fetchWithTimeout } from "@/utils.js";
 import { convertObject, parseXMLString } from "@antonytm/clixml-parser";
-import { PowershellCommandBuilder } from "./command-builder.js";
+import { PowershellCommandBuilder, wrapInScriptContext, DEFAULT_SCRIPT_CONTEXT, type ScriptContext } from "./command-builder.js";
 
 /**
  * Turns a failed SPE response into a message that says what actually answered.
@@ -76,12 +76,25 @@ class PowershellClient {
     private domain: string;
     private bearertoken: string | null = null;
     private commandBuilder: PowershellCommandBuilder = new PowershellCommandBuilder();
+    private context: ScriptContext;
 
-    constructor(serverUrl: string, username: string, password: string, domain: string = 'sitecore') {
+    /**
+     * `context` is the site (and content database) every script runs under — see
+     * `wrapInScriptContext` for why the default is `shell` / `master` rather than whatever
+     * site the request host resolves to. Pass `{ site: "" }` to run scripts unwrapped.
+     */
+    constructor(
+        serverUrl: string,
+        username: string,
+        password: string,
+        domain: string = 'sitecore',
+        context: ScriptContext = DEFAULT_SCRIPT_CONTEXT
+    ) {
         this.serverUrl = serverUrl;
         this.username = username;
         this.password = password;
         this.domain = domain;
+        this.context = context;
         this.bearertoken = "Basic " + Buffer.from(`${username}:${password}`).toString("base64");
     }
 
@@ -96,7 +109,9 @@ class PowershellClient {
         };
 
         const scriptWithParameters = this.commandBuilder.buildCommandString(script, parameters);
-        const body = `${scriptWithParameters}\r\n <#${uuid}#>\r\n`;
+        // The site/database switch wraps the whole script, so a create inside it gets the
+        // template's default workflow the way it would from the Content Editor.
+        const body = `${wrapInScriptContext(scriptWithParameters, this.context)}\r\n <#${uuid}#>\r\n`;
         // Default to 10 minutes. The previous 60s default was tuned to the tool-call
         // timeout most AI agents enforce, but in practice it fired constantly on larger
         // scripts (index rebuilds, publishing, bulk item updates) and aborted work that

--- a/src/tools/powershell/command-builder.ts
+++ b/src/tools/powershell/command-builder.ts
@@ -11,6 +11,60 @@ export function quotePowerShellString(value: unknown): string {
     return `'${String(value).replace(/'/g, "''")}'`;
 }
 
+/** The site and content database a script runs under. Empty `site` means "do not switch". */
+export type ScriptContext = {
+    site?: string;
+    database?: string;
+};
+
+export const DEFAULT_SCRIPT_CONTEXT: Required<ScriptContext> = { site: "shell", database: "master" };
+
+/**
+ * Wraps a script so it runs in a named site context, with `Context.Database` pinned.
+ *
+ * Why this exists: Sitecore applies a template's `__Default workflow` at create time — from a
+ * bare template or a branch alike — only when `Context.Site.EnableWorkflow` is true. The
+ * Content Editor, Pages and the SPE ISE all run in `shell`, where it is. The remoting endpoint
+ * this server calls resolves its site from the request host like any other request, which on
+ * a CM serving several sites is whichever content site claims the hostname (measured
+ * 2026-09-11: `Lifeline`, `EnableWorkflow=False`). A script that created pages there left every
+ * one of them outside its workflow, silently, and nothing downstream noticed for a week.
+ *
+ * `sc_site=shell` on the query string is not an alternative: the shell site demands an
+ * interactive login, so the request is redirected before SPE's basic-auth handler runs.
+ *
+ * Switching to `shell` alone also flips `Context.Database` to `core` (the shell site's own
+ * database), so the content database is pinned too, which is the shape the ISE presents.
+ *
+ * A `try` block opens no new scope in PowerShell, so the caller's variables, output stream and
+ * `return` behave exactly as they did unwrapped. Both names are emitted as single-quoted
+ * literals, so a value from configuration cannot break out of the string.
+ */
+export function wrapInScriptContext(script: string, context: ScriptContext = DEFAULT_SCRIPT_CONTEXT): string {
+    const site = (context.site ?? "").trim();
+    if (site === "") {
+        return script;
+    }
+    const database = (context.database ?? "").trim();
+    const siteLiteral = quotePowerShellString(site);
+    const lines = [
+        `$__mcpSite = [Sitecore.Configuration.Factory]::GetSite(${siteLiteral})`,
+        `if ($null -eq $__mcpSite) { throw ("POWERSHELL_SITE_CONTEXT names no configured site: " + ${siteLiteral}) }`,
+        `$__mcpSiteSwitcher = New-Object Sitecore.Sites.SiteContextSwitcher($__mcpSite)`,
+    ];
+    if (database !== "") {
+        lines.push(
+            `$__mcpDbSwitcher = New-Object Sitecore.Data.DatabaseSwitcher([Sitecore.Configuration.Factory]::GetDatabase(${quotePowerShellString(database)}))`
+        );
+    }
+    lines.push("try {", script, "} finally {");
+    if (database !== "") {
+        lines.push("    $__mcpDbSwitcher.Dispose()");
+    }
+    lines.push("    $__mcpSiteSwitcher.Dispose()", "}");
+    return lines.join("\r\n");
+}
+
 export class PowershellCommandBuilder
 {
     buildCommandString(script: string, parameters: Record<string, any> = {}): string {

--- a/src/tools/powershell/simple/generic.ts
+++ b/src/tools/powershell/simple/generic.ts
@@ -40,7 +40,8 @@ export async function runGenericPowershellCommand(
         config.powershell.serverUrl,
         config.powershell.username,
         config.powershell.password,
-        config.powershell.domain
+        config.powershell.domain,
+        { site: config.powershell.siteContext, database: config.powershell.contextDatabase }
     );
 
     // A projection must be the last stage of the pipeline, so when one is supplied the

--- a/src/tools/powershell/simple/indexing/find-item.ts
+++ b/src/tools/powershell/simple/indexing/find-item.ts
@@ -116,7 +116,8 @@ export async function findItemPowerShellTool(server: McpServer, config: Config) 
         config.powershell.serverUrl,
         config.powershell.username,
         config.powershell.password,
-        config.powershell.domain
+        config.powershell.domain,
+        { site: config.powershell.siteContext, database: config.powershell.contextDatabase }
     );
 
     //https://doc.sitecorepowershell.com/appendix/indexing/find-item

--- a/tests/powershell/simple/common/script-context/run-powershell-script-site-context.test.ts
+++ b/tests/powershell/simple/common/script-context/run-powershell-script-site-context.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { client, transport, callTool } from "../../../../client";
+import { seedScratch, SAMPLE_WORKFLOW } from "../../../../fixtures";
+
+await client.connect(transport);
+
+/**
+ * The regression this file exists for: an item created through `run-powershell-script` used to
+ * land OUTSIDE its template's default workflow, while the same create in the Content Editor
+ * landed in Draft. Sitecore applies `__Default workflow` only when `Context.Site.EnableWorkflow`
+ * is true, and the remoting endpoint resolves its site from the request host — on a multi-site
+ * CM that is a content site with workflow off. The client now wraps every script in a switch
+ * to the `shell` site with the content database pinned, which is what this proves end to end.
+ *
+ * Nothing here depends on seeded content: the template, its standard values and the item are
+ * all the scratch's own, and the cleanup takes the lot.
+ */
+const scratch = await seedScratch("script-context");
+afterAll(() => scratch.cleanup());
+
+describe("powershell", () => {
+    it("run-powershell-script runs as the shell site with master as the context database", async () => {
+        const result = await callTool(client, "run-powershell-script", {
+            script: `@{ site = [Sitecore.Context]::Site.Name; enableWorkflow = [Sitecore.Context]::Site.EnableWorkflow; database = [Sitecore.Context]::Database.Name } | ConvertTo-Json -Compress`,
+        });
+        expect(result.isError).toBeFalsy();
+        const wrapper = JSON.parse(result.content[0].text);
+        const payload = JSON.parse(Array.isArray(wrapper?.Obj) ? wrapper.Obj[0] : wrapper);
+        expect(payload.site).toBe("shell");
+        expect(payload.enableWorkflow).toBe(true);
+        expect(payload.database).toBe("master");
+    });
+
+    it("an item created by a script receives its template's default workflow", async () => {
+        // Arrange: give the scratch template standard values that name the Sample Workflow as
+        // the default. Sitecore's own Sample Workflow ships with every CM, so this seeds nothing.
+        const arrange = await callTool(client, "run-powershell-script", {
+            script: `
+$ErrorActionPreference = "Stop"
+$template = Get-Item -Path "master:${scratch.template.path}"
+$sv = New-Item -Path $template.Paths.Path -Name "__Standard Values" -ItemType $template.ID
+$sv.Editing.BeginEdit() | Out-Null
+$sv["__Default workflow"] = "${SAMPLE_WORKFLOW.id}"
+$sv.Editing.EndEdit() | Out-Null
+$template.Editing.BeginEdit() | Out-Null
+$template["__Standard values"] = $sv.ID.ToString()
+$template.Editing.EndEdit() | Out-Null
+'"arranged"'`.trim(),
+        });
+        expect(arrange.isError).toBeFalsy();
+
+        // Act: create an item the way any agent script would.
+        const act = await callTool(client, "run-powershell-script", {
+            script: `
+$ErrorActionPreference = "Stop"
+$item = New-Item -Path "master:${scratch.root.path}" -Name "Probe" -ItemType "${scratch.template.path}"
+@{ workflow = [string]$item["__Workflow"]; state = [string]$item["__Workflow state"] } | ConvertTo-Json -Compress`.trim(),
+        });
+        expect(act.isError).toBeFalsy();
+        const wrapper = JSON.parse(act.content[0].text);
+        const fields = JSON.parse(Array.isArray(wrapper?.Obj) ? wrapper.Obj[0] : wrapper);
+
+        // Assert against the fixture's constants, not against what the CM happens to hold.
+        expect(fields.workflow.toUpperCase()).toBe(SAMPLE_WORKFLOW.id);
+        expect(fields.state.toUpperCase()).toBe(SAMPLE_WORKFLOW.draft);
+    });
+});

--- a/tests/unit/command-builder.test.ts
+++ b/tests/unit/command-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { PowershellCommandBuilder, quotePowerShellString } from "../../src/tools/powershell/command-builder";
+import { PowershellCommandBuilder, quotePowerShellString, wrapInScriptContext } from "../../src/tools/powershell/command-builder";
 
 describe("quotePowerShellString", () => {
     it("wraps a plain value in single quotes", () => {
@@ -60,5 +60,44 @@ describe("PowershellCommandBuilder.buildParametersString", () => {
     it("renders record parameters as an escaped hashtable", () => {
         const out = builder.buildParametersString({ Props: { Title: "O'Brien" } });
         expect(out).toBe(" -Props @{ 'Title' = 'O''Brien' }");
+    });
+});
+
+describe("wrapInScriptContext", () => {
+    // Why a script is wrapped at all: Sitecore applies a template's default workflow at create
+    // time only when Context.Site.EnableWorkflow is true. The remoting endpoint resolves its site
+    // from the request host, which on a multi-site CM is a content site with workflow OFF, so a
+    // page created through this server landed outside its workflow while the same create in the
+    // Content Editor (site `shell`) landed in Draft.
+    it("wraps the script in a shell site switch with the content database pinned by default", () => {
+        const wrapped = wrapInScriptContext("Get-Item -Path 'master:/sitecore/content'");
+        expect(wrapped).toContain("[Sitecore.Configuration.Factory]::GetSite('shell')");
+        expect(wrapped).toContain("New-Object Sitecore.Sites.SiteContextSwitcher($__mcpSite)");
+        expect(wrapped).toContain("New-Object Sitecore.Data.DatabaseSwitcher([Sitecore.Configuration.Factory]::GetDatabase('master'))");
+        expect(wrapped).toContain("try {\r\nGet-Item -Path 'master:/sitecore/content'\r\n} finally {");
+        // Both switchers are disposed, database first, so the site is restored last.
+        expect(wrapped.indexOf("$__mcpDbSwitcher.Dispose()")).toBeLessThan(wrapped.indexOf("$__mcpSiteSwitcher.Dispose()"));
+    });
+
+    it("returns the script untouched when the site is empty (the documented opt-out)", () => {
+        expect(wrapInScriptContext("1 + 1", { site: "", database: "master" })).toBe("1 + 1");
+        expect(wrapInScriptContext("1 + 1", { site: "   " })).toBe("1 + 1");
+    });
+
+    it("switches the site without pinning a database when the database is empty", () => {
+        const wrapped = wrapInScriptContext("1 + 1", { site: "shell", database: "" });
+        expect(wrapped).toContain("GetSite('shell')");
+        expect(wrapped).not.toContain("DatabaseSwitcher");
+        expect(wrapped).not.toContain("$__mcpDbSwitcher");
+    });
+
+    it("emits the names as single-quoted literals so a configured value cannot escape the string", () => {
+        const wrapped = wrapInScriptContext("1 + 1", { site: "x'; Remove-Item master:/sitecore -Recurse; '", database: "master" });
+        expect(wrapped).toContain("GetSite('x''; Remove-Item master:/sitecore -Recurse; ''')");
+    });
+
+    it("throws inside Sitecore, not silently, when the site does not exist", () => {
+        const wrapped = wrapInScriptContext("1 + 1", { site: "no-such-site" });
+        expect(wrapped).toContain("if ($null -eq $__mcpSite) { throw");
     });
 });


### PR DESCRIPTION
Sitecore applies a template's __Default workflow at create time only when Context.Site.EnableWorkflow is true. The SPE remoting endpoint resolves its site from the request host, which on a multi-site CM is a content site with workflow off, so items created through run-powershell-script (and every SPE-backed tool) silently landed outside their workflow while the same create in the Content Editor landed in Draft.

Wrap every script in a SiteContextSwitcher + DatabaseSwitcher (shell / master by default; a try block opens no scope in PowerShell so output, variables and return are unchanged). New settings POWERSHELL_SITE_CONTEXT and POWERSHELL_CONTEXT_DATABASE; an empty site restores the old behaviour. sc_site=shell on the query string was measured and rejected: the shell site redirects to login before SPE's basic-auth handler runs.

Adds unit coverage for the wrapper and a live test proving a created item receives its template's default workflow.